### PR TITLE
Replace deprecated NgFor usage with @for

### DIFF
--- a/src/app/todo/todo.component.html
+++ b/src/app/todo/todo.component.html
@@ -5,10 +5,12 @@
   </form>
 
   <ul class="space-y-2">
-    <li *ngFor="let todo of todos; let i = index" [class.completed]="todo.completed" class="flex items-center gap-2">
+    @for (todo of todos; let i = $index; track $index) {
+    <li [class.completed]="todo.completed" class="flex items-center gap-2">
       <input type="checkbox" [(ngModel)]="todo.completed" (change)="toggle(todo)" />
       <span class="flex-1">{{ todo.title }}</span>
       <button type="button" (click)="remove(i)" class="text-red-500 hover:underline">Remove</button>
     </li>
+    }
   </ul>
 </div>

--- a/src/app/todo/todo.component.ts
+++ b/src/app/todo/todo.component.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { NgFor } from '@angular/common';
 
 interface Todo {
   title: string;
@@ -10,7 +9,7 @@ interface Todo {
 @Component({
   selector: 'app-todo',
   standalone: true,
-  imports: [FormsModule, NgFor],
+  imports: [FormsModule],
   templateUrl: './todo.component.html',
   styleUrl: './todo.component.scss'
 })


### PR DESCRIPTION
## Summary
- remove deprecated `NgFor` import
- use the new `@for` built‑in in the todo list template

## Testing
- `npm run build`
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_6840922f22e88321b188163ef1b6a814