### PR TITLE
Add Prettier with formatting scripts

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "tabWidth": 2
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,7 @@
 {
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=827846
-  "recommendations": ["angular.ng-template"]
+  "recommendations": [
+    "angular.ng-template",
+    "esbenp.prettier-vscode"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.1.0",
         "postcss": "^8.5.4",
+        "prettier": "^3.5.3",
         "tailwindcss": "^3.4.17",
         "typescript": "~5.8.3"
       }
@@ -11350,6 +11351,22 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/proc-log": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
+    "format": "prettier --write \"src/**/*.{ts,html,scss}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,html,scss}\"",
     "serve:ssr:angular-20-todo-app": "node dist/angular-20-todo-app/server/server.mjs"
   },
   "private": true,
@@ -40,6 +42,7 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "postcss": "^8.5.4",
+    "prettier": "^3.5.3",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.3"
   }


### PR DESCRIPTION
## Summary
- install Prettier
- configure `.prettierrc`
- add `format` and `format:check` npm scripts
- recommend Prettier VS Code extension and enable format on save

## Testing
- `npm test` *(fails: could not complete due to environment)*
- `npm run format --silent`

------
https://chatgpt.com/codex/tasks/task_e_6842c96e4c308321b827e865b4f439ea