### PR TITLE
Add Prettier formatting setup

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "tabWidth": 2,
+  "semi": true,
+  "trailingComma": "es5",
+  "printWidth": 80
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.1.0",
         "postcss": "^8.5.4",
+        "prettier": "^3.2.5",
         "tailwindcss": "^3.4.17",
         "typescript": "~5.8.3"
       }
@@ -12934,6 +12935,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/proc-log": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "test": "ng test",
     "serve:ssr:angular-20-todo-app": "node dist/angular-20-todo-app/server/server.mjs",
     "lint": "ng lint",
-    "prepare": "husky && husky install"
+    "prepare": "husky && husky install",
+    "format": "prettier --write \"src/**/*.{ts,html,scss}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,html,scss}\""
   },
   "private": true,
   "dependencies": {
@@ -51,6 +53,7 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "postcss": "^8.5.4",
     "tailwindcss": "^3.4.17",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "prettier": "^3.2.5"
   }
 }


### PR DESCRIPTION
## Summary
- add a Prettier config
- install Prettier and expose `format`/`format:check` scripts
- add VS Code settings for formatting

## Testing
- `npm test` *(fails: No binary for Chrome)*
- `npm run format:check`

------
https://chatgpt.com/codex/tasks/task_e_68458f590ab48321a23f277276365b67