### PR TITLE
Add simple Express API for products and cart

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ npm install
 # initialize git hooks
 npx husky install
 npm start
+npm run start:backend # starts the product API
 ```
 
 Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
@@ -79,6 +80,28 @@ ng e2e
 
 Angular CLI does not come with an end-to-end testing framework by default. You can choose one that suits your needs.
 
+## Product API
+
+This repository includes a tiny Node.js backend under the `backend/` folder. The Angular app relies on this API for product and cart data.
+
+Start the backend in a separate terminal with:
+
+```bash
+npm run start:backend
+
+The development server is configured to proxy `/api` requests to `http://localhost:3000`, so running `npm start` in another terminal will serve the frontend and forward API calls automatically.
+```
+
+The API exposes the following endpoints:
+
+- `GET /api/products` – list products
+- `GET /api/products/:id` – get a single product
+- `GET /api/cart` – view the current cart
+- `POST /api/cart` – add a product to the cart (`{ productId, quantity }`)
+- `PUT /api/cart/:id` – update quantity
+- `DELETE /api/cart/:id` – remove from cart
+- `POST /api/checkout` – finalize an order
+
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
@@ -87,13 +110,13 @@ For more information on using the Angular CLI, including detailed command refere
 
 The `package.json` exposes a couple of handy commands:
 
-| Script | Description |
-| ------ | ----------- |
-| `npm start` | Alias for `ng serve`. Starts the development server. |
-| `npm run build` | Builds the browser and server bundles. |
-| `npm test` | Runs unit tests with Karma. |
-| `npm run watch` | Rebuilds on file changes. |
-| `npm run serve:ssr:angular-20-todo-app` | Starts the built SSR server. |
+| Script                                  | Description                                          |
+| --------------------------------------- | ---------------------------------------------------- |
+| `npm start`                             | Alias for `ng serve`. Starts the development server. |
+| `npm run build`                         | Builds the browser and server bundles.               |
+| `npm test`                              | Runs unit tests with Karma.                          |
+| `npm run watch`                         | Rebuilds on file changes.                            |
+| `npm run serve:ssr:angular-20-todo-app` | Starts the built SSR server.                         |
 
 ## Contributing
 

--- a/angular.json
+++ b/angular.json
@@ -20,9 +20,7 @@
             "outputPath": "dist/angular-20-todo-app",
             "index": "src/index.html",
             "browser": "src/main.ts",
-            "polyfills": [
-              "zone.js"
-            ],
+            "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
@@ -31,9 +29,7 @@
                 "input": "public"
               }
             ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "styles": ["src/styles.scss"],
             "scripts": [],
             "server": "src/main.server.ts",
             "outputMode": "server",
@@ -67,6 +63,9 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "buildTarget": "angular-20-todo-app:build:production"
@@ -83,10 +82,7 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": [
-              "zone.js",
-              "zone.js/testing"
-            ],
+            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
             "assets": [
@@ -95,19 +91,14 @@
                 "input": "public"
               }
             ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "styles": ["src/styles.scss"],
             "scripts": []
           }
         },
         "lint": {
           "builder": "@angular-eslint/builder:lint",
           "options": {
-            "lintFilePatterns": [
-              "src/**/*.ts",
-              "src/**/*.html"
-            ]
+            "lintFilePatterns": ["src/**/*.ts", "src/**/*.html"]
           }
         }
       }

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,138 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const cors = require('cors');
+
+const app = express();
+app.use(cors());
+app.use(bodyParser.json());
+
+// In-memory product catalogue
+const products = [
+  {
+    id: 1,
+    title: 'Sample Product 1',
+    price: 9.99,
+    image: 'https://placehold.co/300x200?text=Prod+1',
+    images: [
+      'https://placehold.co/600x400?text=Prod+1+-+Image+1',
+      'https://placehold.co/600x400?text=Prod+1+-+Image+2',
+      'https://placehold.co/600x400?text=Prod+1+-+Image+3'
+    ],
+    description: 'Description for product 1.',
+    stock: 5
+  },
+  {
+    id: 2,
+    title: 'Sample Product 2',
+    price: 14.99,
+    image: 'https://placehold.co/300x200?text=Prod+2',
+    images: [
+      'https://placehold.co/600x400?text=Prod+2+-+Image+1',
+      'https://placehold.co/600x400?text=Prod+2+-+Image+2',
+      'https://placehold.co/600x400?text=Prod+2+-+Image+3'
+    ],
+    description: 'Description for product 2.',
+    stock: 8
+  },
+  {
+    id: 3,
+    title: 'Sample Product 3',
+    price: 19.99,
+    image: 'https://placehold.co/300x200?text=Prod+3',
+    images: [
+      'https://placehold.co/600x400?text=Prod+3+-+Image+1',
+      'https://placehold.co/600x400?text=Prod+3+-+Image+2',
+      'https://placehold.co/600x400?text=Prod+3+-+Image+3'
+    ],
+    description: 'Description for product 3.',
+    stock: 3
+  },
+  {
+    id: 4,
+    title: 'Sample Product 4',
+    price: 29.99,
+    image: 'https://placehold.co/300x200?text=Prod+4',
+    images: [
+      'https://placehold.co/600x400?text=Prod+4+-+Image+1',
+      'https://placehold.co/600x400?text=Prod+4+-+Image+2',
+      'https://placehold.co/600x400?text=Prod+4+-+Image+3'
+    ],
+    description: 'Description for product 4.',
+    stock: 10
+  }
+];
+
+let cart = [];
+
+// Products endpoints
+app.get('/api/products', (req, res) => {
+  res.json(products);
+});
+
+app.get('/api/products/:id', (req, res) => {
+  const id = Number(req.params.id);
+  const product = products.find(p => p.id === id);
+  if (product) {
+    res.json(product);
+  } else {
+    res.status(404).json({ message: 'Product not found' });
+  }
+});
+
+// Cart endpoints
+app.get('/api/cart', (req, res) => {
+  res.json(cart);
+});
+
+app.post('/api/cart', (req, res) => {
+  const { productId, quantity } = req.body;
+  const product = products.find(p => p.id === productId);
+  if (!product) {
+    res.status(400).json({ message: 'Invalid product' });
+    return;
+  }
+  const existing = cart.find(i => i.product.id === productId);
+  if (existing) {
+    existing.quantity = Math.min(existing.quantity + (quantity || 1), product.stock);
+  } else {
+    cart.push({ product, quantity: Math.min(quantity || 1, product.stock) });
+  }
+  res.json(cart);
+});
+
+app.put('/api/cart/:id', (req, res) => {
+  const id = Number(req.params.id);
+  const { quantity } = req.body;
+  const item = cart.find(i => i.product.id === id);
+  if (!item) {
+    res.status(404).json({ message: 'Item not in cart' });
+    return;
+  }
+  item.quantity = Math.min(Math.max(quantity, 1), item.product.stock);
+  res.json(cart);
+});
+
+app.delete('/api/cart/:id', (req, res) => {
+  const id = Number(req.params.id);
+  cart = cart.filter(i => i.product.id !== id);
+  res.json(cart);
+});
+
+// Checkout endpoint
+app.post('/api/checkout', (req, res) => {
+  const { name, address } = req.body;
+  if (!cart.length) {
+    res.status(400).json({ message: 'Cart is empty' });
+    return;
+  }
+  const total = cart.reduce((sum, item) => sum + item.product.price * item.quantity, 0);
+  const order = { id: Date.now(), name, address, items: cart, total };
+  // Clear cart after checkout
+  cart = [];
+  res.json({ message: 'Order placed successfully', order });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`API server listening on port ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "serve:ssr:angular-20-todo-app": "node dist/angular-20-todo-app/server/server.mjs",
+    "start:backend": "node backend/server.js",
     "lint": "ng lint",
     "prepare": "husky && husky install",
     "format": "prettier --write \"src/**/*.{ts,html,scss}\"",
@@ -25,6 +26,7 @@
     "@angular/router": "^20.0.0",
     "@angular/ssr": "^20.0.0",
     "express": "^4.18.2",
+    "cors": "^2.8.5",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,0 +1,7 @@
+{
+  "/api": {
+    "target": "http://localhost:3000",
+    "secure": false,
+    "changeOrigin": true
+  }
+}

--- a/src/app/app.config.server.ts
+++ b/src/app/app.config.server.ts
@@ -2,14 +2,13 @@ import { provideServerRendering, withRoutes } from '@angular/ssr';
 import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
 import { appConfig } from './app.config';
 import { serverRoutes } from './app.routes.server';
-import { CART_STORAGE } from './services/cart/cart.models';
-import { MemoryCartStorage } from './services/cart/memory-cart-storage.service';
+import { provideHttpClient, withFetch } from '@angular/common/http';
 
 const serverConfig: ApplicationConfig = {
   providers: [
     provideServerRendering(withRoutes(serverRoutes)),
-    { provide: CART_STORAGE, useClass: MemoryCartStorage }
-  ]
+    provideHttpClient(withFetch()),
+  ],
 };
 
 export const config = mergeApplicationConfig(appConfig, serverConfig);

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -2,15 +2,17 @@ import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
-import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
-import { CART_STORAGE } from './services/cart/cart.models';
-import { LocalStorageCartStorage } from './services/cart/local-storage-cart-storage.service';
+import {
+  provideClientHydration,
+  withEventReplay,
+} from '@angular/platform-browser';
+import { provideHttpClient, withFetch } from '@angular/common/http';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideClientHydration(withEventReplay()),
-    { provide: CART_STORAGE, useClass: LocalStorageCartStorage }
-  ]
+    provideHttpClient(withFetch()),
+  ],
 };

--- a/src/app/pages/checkout/checkout.component.ts
+++ b/src/app/pages/checkout/checkout.component.ts
@@ -28,8 +28,9 @@ export class CheckoutComponent {
   }
 
   submit() {
-    this.cart.clear();
-    this.toast.show('Order placed!');
-    this.router.navigate(['/confirmation']);
+    this.cart.checkout(this.name, this.address).subscribe(() => {
+      this.toast.show('Order placed!');
+      this.router.navigate(['/confirmation']);
+    });
   }
 }

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -11,9 +11,9 @@ import { ProductCardComponent } from '../../components/product-card/product-card
   styleUrl: './home.component.scss'
 })
 export class HomeComponent {
-  products: Product[];
+  products: Product[] = [];
 
   constructor(private productService: ProductService) {
-    this.products = this.productService.getProducts();
+    this.productService.getProducts().subscribe(p => (this.products = p));
   }
 }

--- a/src/app/pages/product-detail/product-detail.component.ts
+++ b/src/app/pages/product-detail/product-detail.component.ts
@@ -23,8 +23,10 @@ export class ProductDetailComponent {
     private toast: ToastService
   ) {
     const id = Number(this.route.snapshot.paramMap.get('id'));
-    this.product = this.productService.getProduct(id);
-    this.currentImage = this.product?.images[0] || this.product?.image;
+    this.productService.getProduct(id).subscribe(p => {
+      this.product = p;
+      this.currentImage = p.images[0] || p.image;
+    });
   }
 
   addToCart() {

--- a/src/app/services/cart/cart.models.ts
+++ b/src/app/services/cart/cart.models.ts
@@ -1,4 +1,3 @@
-import { InjectionToken } from '@angular/core';
 import type { Product } from '../product.service';
 
 export interface CartItem {
@@ -6,9 +5,3 @@ export interface CartItem {
   quantity: number;
 }
 
-export interface CartStorage {
-  load(): CartItem[];
-  save(items: CartItem[]): void;
-}
-
-export const CART_STORAGE = new InjectionToken<CartStorage>('CartStorage');

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -1,4 +1,6 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
 
 export interface Product {
   id: number;
@@ -12,66 +14,13 @@ export interface Product {
 
 @Injectable({ providedIn: 'root' })
 export class ProductService {
-  private products: Product[] = [
-    {
-      id: 1,
-      title: 'Sample Product 1',
-      price: 9.99,
-      image: 'https://placehold.co/300x200?text=Prod+1',
-      images: [
-        'https://placehold.co/600x400?text=Prod+1+-+Image+1',
-        'https://placehold.co/600x400?text=Prod+1+-+Image+2',
-        'https://placehold.co/600x400?text=Prod+1+-+Image+3',
-      ],
-      description: 'Description for product 1.',
-      stock: 5
-    },
-    {
-      id: 2,
-      title: 'Sample Product 2',
-      price: 14.99,
-      image: 'https://placehold.co/300x200?text=Prod+2',
-      images: [
-        'https://placehold.co/600x400?text=Prod+2+-+Image+1',
-        'https://placehold.co/600x400?text=Prod+2+-+Image+2',
-        'https://placehold.co/600x400?text=Prod+2+-+Image+3',
-      ],
-      description: 'Description for product 2.',
-      stock: 8
-    },
-    {
-      id: 3,
-      title: 'Sample Product 3',
-      price: 19.99,
-      image: 'https://placehold.co/300x200?text=Prod+3',
-      images: [
-        'https://placehold.co/600x400?text=Prod+3+-+Image+1',
-        'https://placehold.co/600x400?text=Prod+3+-+Image+2',
-        'https://placehold.co/600x400?text=Prod+3+-+Image+3',
-      ],
-      description: 'Description for product 3.',
-      stock: 3
-    },
-    {
-      id: 4,
-      title: 'Sample Product 4',
-      price: 29.99,
-      image: 'https://placehold.co/300x200?text=Prod+4',
-      images: [
-        'https://placehold.co/600x400?text=Prod+4+-+Image+1',
-        'https://placehold.co/600x400?text=Prod+4+-+Image+2',
-        'https://placehold.co/600x400?text=Prod+4+-+Image+3',
-      ],
-      description: 'Description for product 4.',
-      stock: 10
-    }
-  ];
+  private http = inject(HttpClient);
 
-  getProducts() {
-    return this.products;
+  getProducts(): Observable<Product[]> {
+    return this.http.get<Product[]>('/api/products');
   }
 
-  getProduct(id: number) {
-    return this.products.find(p => p.id === id);
+  getProduct(id: number): Observable<Product> {
+    return this.http.get<Product>(`/api/products/${id}`);
   }
 }


### PR DESCRIPTION
## Summary
- implement a small Express backend under `backend/` handling products, cart and checkout
- document running the backend and available endpoints
- add a dev-server proxy and enable HttpClient fetch mode

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845aa82fe948321bcfe4895282fede7